### PR TITLE
The minimum changes required for js_of_ocaml

### DIFF
--- a/lib/binary_packing.ml
+++ b/lib/binary_packing.ml
@@ -787,7 +787,7 @@ module Inline_signed_32_int_test_(T : sig end) = struct end
 
 module Inline_signed_int_test_ = 
   (val (if arch64 then (module Inline_signed_64_int_test_ : Apply_functor_for_sideeffect)
-        else (module Inline_signed_64_int_test_ : Apply_functor_for_sideeffect)))
+        else (module Inline_signed_32_int_test_ : Apply_functor_for_sideeffect)))
 
 (* execute the tests, if required *)
 module Inline_signed_int_test = Inline_signed_int_test_(struct end)

--- a/lib/core_int63.ml
+++ b/lib/core_int63.ml
@@ -1,7 +1,20 @@
-INCLUDE "config.mlh"
-IFDEF ARCH_SIXTYFOUR THEN
-include Core_int
-let to_int x = Some x
-ELSE
-include Core_int64
-ENDIF
+module type S = sig
+  include Int_intf.S
+  val of_int : int -> t
+  val to_int : t -> int option
+end
+
+module Arch64 = struct
+  include Core_int
+  let to_int x = Some x
+end
+
+(* select implementation *)
+module Arch = 
+  (val if Word_size.(word_size = W64) then 
+         (module Arch64 : S) 
+       else 
+         (module Core_int64 : S))
+
+include Arch
+

--- a/lib/core_int63.mli
+++ b/lib/core_int63.mli
@@ -15,21 +15,15 @@
       large of an int from a 32-bit to a 64-bit platform.  This is couterintuitive because
       the 32-bit platform has the larger int size. *)
 
-INCLUDE "config.mlh"
-
-IFDEF ARCH_SIXTYFOUR THEN
-
-(** We expose [private int] so that the compiler can omit caml_modify when dealing with
+(** WARNING: XXX The following is no longer valid and I don't know how to make it so 
+                 when the implementation is dynamically selected at run time rather than
+                 build time XXX
+   
+    We expose [private int] so that the compiler can omit caml_modify when dealing with
     record fields holding [Int63.t].  Code should not explicitly make use of the
     [private], e.g. via [(i :> int)], since such code will not compile on 32-bit
     platforms. *)
-include Int_intf.S with type t = private int
-
-ELSE
-
-include Int_intf.S
-
-ENDIF
+include Int_intf.S (* with type t = private int *)
 
 val of_int : int -> t
 val to_int : t -> int option

--- a/lib/core_kernel_runtime.js
+++ b/lib/core_kernel_runtime.js
@@ -1,0 +1,30 @@
+//Provides: unix_gethostname
+//Requires: caml_new_string
+function unix_gethostname() {
+  return caml_new_string('localhost');
+}
+
+//Provides: caml_hash_string
+//Requires: caml_hash
+function caml_hash_string(str) { return caml_hash(10,100,0,str); }
+
+//Provides: caml_hash_double
+//Requires: caml_hash
+function caml_hash_double(num) { return caml_hash(10,100,0,num); }
+
+//Provides: core_array_unsafe_float_blit
+//Requires: caml_array_blit
+function core_array_unsafe_float_blit(a1, i1, a2, i2, len) { 
+  return caml_array_blit(a1, i1, a2, i2, len);
+}
+
+//Provides: core_array_unsafe_int_blit
+//Requires: caml_array_blit
+function core_array_unsafe_int_blit(a1, i1, a2, i2, len) { 
+  return caml_array_blit(a1, i1, a2, i2, len);
+}
+
+//Provides: fixed_close_channel
+//Requires: caml_ml_close_channel
+function fixed_close_channel(num) { return caml_ml_close_channel(num); }
+

--- a/lib/pool.ml
+++ b/lib/pool.ml
@@ -105,19 +105,17 @@ module Pool = struct
     TEST = t11 = max_slot
   end
 
-IFDEF ARCH_SIXTYFOUR THEN
+  (* This code has been changed to accommodate js_of_ocaml.  It previously used 
+     'IFDEF ARCH_SIXTYFOUR' to choose these settings and would assert if Int.num_bits
+     was not of an expected size.
 
-  let () = assert (Int.num_bits = 63)
-  let array_index_num_bits = 30
-  let masked_tuple_id_num_bits = 33
-
-ELSE
-
-  let () = assert (Int.num_bits = 31)
-  let array_index_num_bits = 27
-  let masked_tuple_id_num_bits = 4
-
-ENDIF
+     NOTE: other ARCH_SIXTYFOUR defines in this file will also need to be changeed 
+     to ensure correct operation of the module, but this is enough to get 
+     core_kernel to run in js_of_ocaml.
+  *)
+  let array_index_num_bits, masked_tuple_id_num_bits = 
+    if Int.num_bits = 63 then 30, 33
+    else 27, 4
 
   TEST = array_index_num_bits > 0
   TEST = masked_tuple_id_num_bits > 0


### PR DESCRIPTION
- Removes an integer bit size based assert from pool.ml
- Adds the required js_of_ocaml runtime javascript
