### PR TITLE
int64_t is defined in stdint.h, thus including stdint.h here.

### DIFF
--- a/lib/int_math_stubs.c
+++ b/lib/int_math_stubs.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <caml/alloc.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>


### PR DESCRIPTION
otherwise, core_kernel fails to compile on FreeBSD
