### PR TITLE
Build with trunk

### DIFF
--- a/lib/binary_packing.ml
+++ b/lib/binary_packing.ml
@@ -324,7 +324,6 @@ let check_signed_32_in_range n =
       raise (Pack_signed_32_argument_out_of_range n)
   ENDIF
 
-exception Pack_signed_32_argument_out_of_range of int with sexp
 let pack_signed_32_int ~byte_order ~buf ~pos n =
   assert (Sys.word_size = 64);
   check_signed_32_in_range n;

--- a/lib/core_gc_stubs.c
+++ b/lib/core_gc_stubs.c
@@ -1,4 +1,6 @@
 #include <caml/memory.h>
+#define CAML_NAME_SPACE
+#include <caml/compatibility.h>
 
 extern double caml_stat_minor_words;
 extern double caml_stat_promoted_words;

--- a/lib/hash_stubs.c
+++ b/lib/hash_stubs.c
@@ -1,5 +1,6 @@
 #include <caml/mlvalues.h>
 #include <caml/hash.h>
+#include <stdint.h>
 
 /* Final mix and return from the hash.c implementation from INRIA */
 #define FINAL_MIX_AND_RETURN(h) \
@@ -12,14 +13,14 @@
 
 CAMLprim value caml_hash_string (value string) 
 {
-  uint32 h;
+  uint32_t h;
   h = caml_hash_mix_string (0, string);
   FINAL_MIX_AND_RETURN(h)
 }
 
 CAMLprim value caml_hash_double (value d)
 {
-  uint32 h;
+  uint32_t h;
   h = caml_hash_mix_double (0, Double_val(d));
   FINAL_MIX_AND_RETURN (h);
 }


### PR DESCRIPTION
* uint32 is not defined anymore in OCaml headers. Replace it with uint32_t
  that should be defined by any reasonnable compiler.
* trunk forbid the redeclaration of exceptions. Remove the redeclaration
  of Binary_packing.Pack_signed_32_argument_out_of_range that looks like
  a typo.