### PR TITLE
Use <endian.h> instead of <sys/endian.h>

### DIFF
--- a/src/bigstring_stubs.c
+++ b/src/bigstring_stubs.c
@@ -33,7 +33,7 @@
 #include <endian.h>
 #else
 #include <sys/types.h>
-#include <sys/endian.h>
+#include <endian.h>
 #define __BYTE_ORDER    _BYTE_ORDER
 #define __LITTLE_ENDIAN _LITTLE_ENDIAN
 #define __BIG_ENDIAN    _BIG_ENDIAN


### PR DESCRIPTION
Fixes compilation on musl-libc based distributions such as Alpine
Linux, and continues to work on Ubuntu.