### PR TITLE
More efficient union-find implementation using GADTs and inline records

### DIFF
--- a/src/union_find.ml
+++ b/src/union_find.ml
@@ -44,77 +44,84 @@ end
   deepest node takes Theta(N) time.  With the balancing scheme of never
   increasing the rank of a node unnecessarily, it would take O(log N).
 *)
-type 'a root = {
-  mutable value: 'a;
-  mutable rank: int;
-}
 
-type 'a t = { mutable node : 'a node; }
+(* NOTE: This does not work yet due to an OCaml 4.04 beta bug.  Should be
+   fixed before the release of OCaml 4.04. *)
+(* type ('a, 'kind) tree = *)
+(*   | Root : { mutable value : 'a; mutable rank : int } -> ('a, [ `root ]) tree *)
+(*   | Inner : { mutable parent : 'a node } -> ('a, [ `inner ]) tree *)
+(*  *)
+(* and 'a node = Node : ('a, _) tree -> 'a node  [@@ocaml.unboxed] *)
+(*  *)
+(* type 'a t = ('a, [ `inner ]) tree *)
 
-and 'a node =
-  | Inner of 'a t (* [Inner x] is a node whose parent is [x]. *)
-  | Root of 'a root
+type ('a, 'kind, 'parent) tree =
+  | Root : { mutable value : 'a; mutable rank : int } ->
+    ('a, [ `root ], 'parent) tree
+  | Inner : { mutable parent : 'parent } -> ('a, [ `inner ], 'parent) tree
+
+type 'a node = Node : ('a, _, 'a node) tree -> 'a node  [@@ocaml.unboxed]
+
+type 'a t = ('a, [ `inner ], 'a node) tree
 
 let invariant t =
-  let rec loop t depth =
-    match t.node with
-    | Inner t -> loop t (depth + 1)
-    | Root r -> assert (depth <= r.rank)
+  let rec loop (Inner inner) depth =
+    match inner.parent with
+    | Node (Inner _ as parent) -> loop parent (depth + 1)
+    | Node (Root r) -> assert (depth <= r.rank)
   in
   loop t 0
 
-let create v = { node = Root { value = v; rank = 0; }; }
+let create v = Inner { parent = Node (Root { value = v; rank = 0 }) }
 
-(* invariants:
-   [inner.node] = [inner_node] = [Inner t].
-   [descendants] are the proper descendants of [inner] we've visited.
-*)
-let rec compress t ~inner_node ~inner ~descendants =
-  match t.node with
-  | Root r ->
-    (* t is the root of the tree.
-       Re-point all descendants directly to it by setting them to [Inner t].
-       Note: we don't re-point [inner] as it already points there. *)
-    List.iter descendants ~f:(fun t -> t.node <- inner_node); (t, r)
-  | Inner t' as node ->
-    compress t' ~inner_node:node ~inner:t ~descendants:(inner :: descendants)
+(* NOTE: does not use tail-recursion like previous implementation, because
+   the depth should never exceed O(log N) anyway.  It's faster this way. *)
+let rec compress ~repr:(Inner inner as repr) = function
+  | Node (Root _ as root) -> repr, root
+  | Node (Inner next_inner as repr) ->
+      let repr, _ as res = compress ~repr next_inner.parent in
+      inner.parent <- Node repr;
+      res
 
-let representative t =
-  match t.node with
-  | Root r -> (t, r)
-  | Inner t' as node -> compress t' ~inner_node:node ~inner:t ~descendants:[]
+let compress_inner (Inner inner as repr) = compress ~repr inner.parent
 
-let root t = snd (representative t)
+let get_root (Inner inner) =
+  match inner.parent with
+  | Node (Root _ as root) -> root  (* Avoids compression call *)
+  | Node (Inner _ as repr) ->
+      let repr, root = compress_inner repr in
+      inner.parent <- Node repr;
+      root
 
-let get t = (root t).value
+let get t = let Root r = get_root t in r.value
 
-let set t v = (root t).value <- v
+let set t x = let Root r = get_root t in r.value <- x
 
-let same_class t1 t2 = phys_equal (root t1) (root t2)
+let same_class t1 t2 = phys_equal (get_root t1) (get_root t2)
 
 let union t1 t2 =
-  let (t1, r1) = representative t1 in
-  let (t2, r2) = representative t2 in
-  if phys_equal r1 r2 then
+  let Inner inner1 as repr1, (Root r1 as root1) = compress_inner t1 in
+  let Inner inner2 as repr2, (Root r2 as root2) = compress_inner t2 in
+  if phys_equal root1 root2 then
     ()
   else
     let n1 = r1.rank in
     let n2 = r2.rank in
     if n1 < n2 then
-      t1.node <- Inner t2
+      inner1.parent <- Node repr2
     else begin
-      t2.node <- Inner t1;
+      inner2.parent <- Node repr1;
       if n1 = n2 then r1.rank <- r1.rank + 1;
     end
 
 let%test_module _ = (module struct
 
-  let is_compressed t =
+  let is_compressed (Inner t) =
     invariant t;
-    match t.node with
+    match t.parent with
     | Root _ -> true
     | Inner t ->
-      match t.node with
+      match t.parent with
       | Root _ -> true
       | Inner _ -> false
   ;;


### PR DESCRIPTION
This branch implements changes to the union-find implementation to make it more efficient by removing indirections, thus eliminating extra heap blocks and pointer dereferencing.  This is achieved by combining GADTs and inline records.  This trick can likely be used in many other contexts.

There are no API changes.  The changes have been tested, but should also be tested with the internal Jane Street test suite.

There is currently a small bug in the beta 2 of OCaml 4.04 that prevents me from implementing the type definitions in a more straightforward way.  The workaround using a type variable is only mildly more complicated.  Note that OCaml 4.04, which can unbox single tag constructors, is required to see efficiency gains.

The algorithm now also does not use tail recursion in the compression loop anymore to avoid expensive list allocations.  The worst case recursion depth cannot realistically blow the stack anyway due to the O(log N) bound.