### PR TITLE
Performance fix for removing elements from doubly linked lists

### DIFF
--- a/src/doubly_linked.ml
+++ b/src/doubly_linked.ml
@@ -242,12 +242,14 @@ end = struct
     unsafe_split_or_splice_after t node;
     node
 
+  let dummy_header = Header.create ()
+
   let unlink_before t =
     let node = t.prev in
     if is_singleton node then node else begin
       Header.incr_length t.header ~by:(-1);
       unsafe_split_or_splice_before t node;
-      node.header <- Header.create ();
+      node.header <- dummy_header;
       node
     end
 
@@ -256,7 +258,7 @@ end = struct
     if is_singleton node then node else begin
       Header.incr_length t.header ~by:(-1);
       unsafe_split_or_splice_after t node;
-      node.header <- Header.create ();
+      node.header <- dummy_header;
       node
     end
 


### PR DESCRIPTION
While implementing the GADT-improvement for doubly linked lists I came across this apparently highly significant performance bug.  Removing elements from doubly linked lists basically allocates a lot of stuff needlessly: list headers that are never needed, which again require allocation of union-find data structures.

I have tested the patch below, which only changes three lines of code, and seen performance improvements for realistic, if not to say frequent, use cases close to 100% - not just for the removal operation, for the whole benchmark!  E.g. `insert_first` a couple of million elements into a doubly linked list and then remove them again (removed in reverse order, as tested).

Note that this change makes the GADT-improvement relatively more valuable (almost twice as much), too.

The reason why the patch should be safe is that the dummy header is never used in active lists.  This makes any union find comparison between the dummy header and active headers fail as required.  There is no place in the code where two previously removed elements with dummy headers could interact without being tested against a live header.  Hence there should not be any semantic difference.
