### PR TITLE
Add Core_kernel.( ^/ ) mirroring Core.( ^/ )

### DIFF
--- a/src/core_kernel.ml
+++ b/src/core_kernel.ml
@@ -219,3 +219,5 @@ module Core_kernel_private = struct
 
   module Time_ns_alternate_sexp = Time_ns_alternate_sexp
 end
+
+let ( ^/ ) = Filename.concat


### PR DESCRIPTION
Not one of my more profound contributions, but an irritating omission when you just replaced `open! Core` with `open! Core_kernel` while getting your stuff to run on Windows :wink: