### PR TITLE
MSVC supported unused attribute

### DIFF
--- a/version_util/src/version_util_fallback_stubs.c
+++ b/version_util/src/version_util_fallback_stubs.c
@@ -9,12 +9,21 @@
 #include <caml/memory.h>
 #include <caml/alloc.h>
 
-CAMLprim CAMLweakdef value generated_hg_version (value unit __attribute__ ((unused)))
+#if defined(_MSC_VER) && _MSC_VER >= 1500
+# define __unused(x) __pragma( warning (push) ) \
+    __pragma( warning (disable:4189 ) ) \
+    x \
+    __pragma( warning (pop))
+#else
+# define __unused(x) x __attribute__((unused))
+#endif
+
+CAMLprim CAMLweakdef value generated_hg_version (__unused(value unit))
 {
   return(caml_copy_string(""));
 }
 
-CAMLprim CAMLweakdef value generated_build_info (value unit __attribute__ ((unused)))
+CAMLprim CAMLweakdef value generated_build_info (__unused(value unit))
 {
   return(caml_copy_string(""));
 }


### PR DESCRIPTION
MSVC does not support the GNU `__attribute__((unused))` extension.

Signed-off-by: Jonah Beckford <71855677+jonahbeckford@users.noreply.github.com>